### PR TITLE
add local storage hook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "styled-components": "^6.0.2",
+        "use-local-storage-state": "^19.3.1",
         "uuid": "^10.0.0"
       },
       "devDependencies": {
@@ -11552,6 +11553,22 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-local-storage-state": {
+      "version": "19.3.1",
+      "resolved": "https://registry.npmjs.org/use-local-storage-state/-/use-local-storage-state-19.3.1.tgz",
+      "integrity": "sha512-y3Z1dODXvZXZB4qtLDNN8iuXbsYD6TAxz61K58GWB9/yKwrNG9ynI0GzCTHi/Je1rMiyOwMimz0oyFsZn+Kj7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/astoilkov"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "styled-components": "^6.0.2",
+    "use-local-storage-state": "^19.3.1",
     "uuid": "^10.0.0"
   },
   "devDependencies": {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,12 +1,14 @@
 import GlobalStyle from "../styles";
-import { useState } from "react";
+import useLocalStorageState from "use-local-storage-state";
 import ingredientsData from "@/assets/ingredients.json";
 import { nanoid } from "nanoid";
 import Navigation from "@/components/Navigation";
 import SearchComponent from "@/components/SearchComponent";
 
 export default function App({ Component, pageProps }) {
-  const [ingredients, setIngredients] = useState(ingredientsData);
+  const [ingredients, setIngredients] = useLocalStorageState("ingredients", {
+    defaultValue: ingredientsData,
+  });
 
   const addIngredient = (newIngredient) => {
     const updatedIngredients = [


### PR DESCRIPTION
add local storage to the app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The app now stores the `ingredients` state in local storage, allowing your data to persist even after closing the browser.

- **Chores**
  - Updated dependencies to include `use-local-storage-state` for enhanced local storage management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->